### PR TITLE
Feature validate uic tic belongs to region

### DIFF
--- a/app/models/uic.rb
+++ b/app/models/uic.rb
@@ -2,4 +2,19 @@ class Uic < ActiveRecord::Base
   belongs_to :region
   validates :region_id, :number, presence: true
   validates_uniqueness_of :number
+
+  # Returns +true+ if Uic belongs to +other_region+
+  # which is a Region object of any kind (:city, :adm_region, :mun_region)
+  #
+  def belongs_to_region?( other_region )
+    return false unless region.present?
+    if (
+      ( region == other_region ) ||
+      ( region.try(:parent) == other_region ) ||
+      ( region.try(:parent).try(:parent) == other_region )
+    )
+      return true
+    end
+    false
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,7 +9,9 @@ class User < ActiveRecord::Base
   has_many :user_roles, dependent: :destroy
   has_many :roles, through: :user_roles
 
-  has_many :user_current_roles, dependent: :destroy, autosave: true
+  has_many :user_current_roles, dependent: :destroy, autosave: true, inverse_of: :user
+  validates_associated :user_current_roles
+
   has_many :current_roles, through: :user_current_roles  #роли наблюдателя/члена комиссии
 
   belongs_to :region

--- a/app/models/user_current_role.rb
+++ b/app/models/user_current_role.rb
@@ -28,9 +28,9 @@ class UserCurrentRole < ActiveRecord::Base
   def tic_belongs_to_region
     return true unless region.present?
     if user.region.present? && user.region != region
-      errors.add(:region, "ТИК и район пользователя не совпадают")
+      errors.add(:region, "не совпадает с районом пользователя")
     elsif user.adm_region.present? && region.parent.present? && user.adm_region != region.parent
-      errors.add(:region, "ТИК и адм.округ пользователя не совпадают")
+      errors.add(:region, "не совпадает с адм.округом пользователя")
     end
   end
 

--- a/app/models/user_current_role.rb
+++ b/app/models/user_current_role.rb
@@ -3,10 +3,12 @@ class UserCurrentRole < ActiveRecord::Base
   belongs_to :nomination_source
   belongs_to :region
   belongs_to :uic
-  belongs_to :user
+  belongs_to :user, inverse_of: :user_current_roles
 
   validates :current_role, presence: true
   validate :region_or_uic_present
+  validate :tic_belongs_to_region
+  validate :uic_belongs_to_region
 
   delegate :number, :to => :uic, :prefix => true, :allow_nil => true
   def uic_number=(number)
@@ -22,4 +24,23 @@ class UserCurrentRole < ActiveRecord::Base
       errors.add(:region, "Надо выбрать ТИК или УИК")
     end
   end
+
+  def tic_belongs_to_region
+    return true unless region.present?
+    if user.region.present? && user.region != region
+      errors.add(:region, "ТИК и район пользователя не совпадают")
+    elsif user.adm_region.present? && region.parent.present? && user.adm_region != region.parent
+      errors.add(:region, "ТИК и адм.округ пользователя не совпадают")
+    end
+  end
+
+  def uic_belongs_to_region
+    return true unless uic.present?
+    if user.region.present? && !uic.belongs_to_region?( user.region )
+      errors.add(:uic_number, "Район УИК и район пользователя не совпадают")
+    elsif user.adm_region.present? && !uic.belongs_to_region?( user.adm_region )
+      errors.add(:uic_number, "Адм.округ УИК и пользователя не совпадают")
+    end
+  end
+
 end

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -324,8 +324,10 @@ ru:
       user_current_role:
         current_role: Роль
         adm_region_id: Адм регион
-        region: Регион
+        region: Регион/ТИК
         uic: УИК
+      user_current_roles:
+        region: ТИК
       organisation:
         name: Название
         created_at: Создано


### PR DESCRIPTION
Добавлены проверки принадлежности УИК и/или ТИК району и/или адм.округу пользователя, 
при редактировании пользователя (относится также к принятию заявки и расстановкам).
.
https://www.pivotaltracker.com/story/show/55874454
