### PR TITLE
Fix admin users filters uic roles 2

### DIFF
--- a/app/admin/user.rb
+++ b/app/admin/user.rb
@@ -104,7 +104,7 @@ ActiveAdmin.register User do
   filter :organisation, label: 'Организация', as: :select, collection: proc { Organisation.order(:name).all }, :input_html => {:style => "width: 230px;"}
   filter :roles, :input_html => {:style => "width: 230px;"}
   filter :user_current_roles_current_role_id, label: 'Роль наблюдателя', as: :select, collection: proc { CurrentRole.all }, :input_html => {:style => "width: 230px;"}
-  filter :user_app_uic, as: :numeric, label: '№ УИК'
+  filter :user_app_uic_matcher, as: :string, label: '№ УИК'
   filter :user_app_last_name, as: :string, label: 'Фамилия'
   filter :email, label: 'Почта'
   filter :user_app_created_at, as: :date_range, label: 'Дата подачи заявки'

--- a/app/models/user_app.rb
+++ b/app/models/user_app.rb
@@ -207,6 +207,17 @@ class UserApp < ActiveRecord::Base
     @imported = true
   end
 
+  # Разбивает содержимое поля uic на отдельные номера:
+  # '1234,1235,1236' => '(1234),(1235),(1236)''
+  #
+  # В результате ransacker работает для:
+  #   uic_matcher_contains - возвращает true, если uic содержит искомый номер
+  #   uic_matcher_equals - возвращает true, если uic состоит в точности из одного искомого номера
+  #
+  ransacker :uic_matcher, type: :string, formatter: ->(str){ '('+str+')' } do |parent|
+    Arel::Nodes::NamedFunction.new( 'regexp_replace', [ parent.table[:uic], '[0-9]+', '(\\&)', 'g' ] )
+  end
+
   private
 
   def set_phone_verified_status


### PR DESCRIPTION
уух..
Исправлен фильтр по УИК в пользователях — ситуация, когда у пользователя указано несколько УИК отрабатывается корректно.

Поиск происходит по полным номерам, частичное совпадение номера не учитывается.

https://www.pivotaltracker.com/story/show/55822950
