### PR TITLE
Установка года из заявки для пользователей, у которых он не установлен

### DIFF
--- a/db/migrate/20130902133030_update_users_year_born.rb
+++ b/db/migrate/20130902133030_update_users_year_born.rb
@@ -1,0 +1,7 @@
+class UpdateUsersYearBorn < ActiveRecord::Migration
+  def change
+    User.all.find_each do |user|
+      user.update_column :year_born, user.user_app.year_born if user.year_born.nil? && user.user_app
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20130902101754) do
+ActiveRecord::Schema.define(version: 20130902133030) do
 
   create_table "active_admin_comments", force: true do |t|
     t.string   "namespace"
@@ -96,10 +96,10 @@ ActiveRecord::Schema.define(version: 20130902101754) do
   add_index "roles", ["slug"], name: "index_roles_on_slug", unique: true, using: :btree
 
   create_table "uics", force: true do |t|
-    t.integer  "region_id",                    null: false
+    t.integer  "region_id",                          null: false
     t.integer  "number"
-    t.boolean  "is_temporary", default: false, null: false
-    t.string   "has_koib",     default: "f",   null: false
+    t.boolean  "is_temporary",       default: false, null: false
+    t.string   "has_koib",           default: "f",   null: false
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer  "kind"


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/56187596

Пропускать 1913 не вижу смысла. Он сейчас проставляется пользователям и если пропускать, то старые пользователи будут иметь null, а новые импортированные 1913.
