### PR TITLE
Revert "Убран rvm из gemfile, причина проблем с уникорном найдена" - у м...

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,7 +28,7 @@ gem 'slim'
 
 gem 'honeybadger'
 gem 'therubyracer', platforms: :ruby
-
+gem 'rvm'
 gem 'unicorn'
 gem 'foreman', require: false
 gem 'foreman-export-initscript', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -58,10 +58,6 @@ GEM
     atomic (1.1.13)
     awesome_nested_set (2.1.6)
       activerecord (>= 3.0.0)
-    axlsx (1.3.6)
-      htmlentities (~> 4.3.1)
-      nokogiri (>= 1.4.1)
-      rubyzip (>= 0.9.5)
     bcrypt-ruby (3.1.2)
     bourbon (3.1.8)
       sass (>= 3.2.0)
@@ -280,6 +276,7 @@ GEM
       rspec-mocks (~> 2.14.0)
     ruby-ole (1.2.11.7)
     rubyzip (1.0.0)
+    rvm (1.11.3.8)
     rvm-capistrano (1.4.4)
       capistrano (>= 2.15.4)
     sass (3.2.10)
@@ -390,6 +387,7 @@ DEPENDENCIES
   resque_mailer
   roo
   rspec-rails
+  rvm
   rvm-capistrano
   sass-rails (~> 4.0.0)
   select2-rails


### PR DESCRIPTION
...еня почему-то это ломает запуск rake db:migrate, оставил как было

This reverts commit d2efd828f5cb7c29c0142e2470e51215fcd2a09e.
