### PR TITLE
Временное увеличение таймаута для импорта

### DIFF
--- a/config/unicorn.rb
+++ b/config/unicorn.rb
@@ -26,7 +26,7 @@ require 'bundler/setup'
 
 worker_processes 2
 
-timeout 30
+timeout 60
 
 preload_app true
 


### PR DESCRIPTION
Импорт с 30 секундами проходит только для 130 записей. Чтобы как-то получше было, решили временно увеличить таймаут, чтобы при импорте за раз проходило 250 записей.
