### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 Подробности и постановки(реализовано не всё) можно посмотреть на [wiki](https://github.com/fbkinfo/rosvybory/wiki)
 
 
-##Описание
+## Описание
 
 В проекте логически можно выделить следующие основные части:
 
@@ -28,12 +28,12 @@
  - Список зафикцированных сообщений в админке `/control/call_center_reports` с возможностью модерации. Через redis и node.js реализована эксперементальная поддержка подгрузки сообщений в реальном времени.
  - Выгрузка нарушений в JSON-файл / загрузка данных на карту нарушений в реальном времени - через Resque
  
-##Установка
+## Установка
 
 Пример разворачивания на ubuntu [есть в вики](https://github.com/fbkinfo/rosvybory/wiki/%D0%A0%D0%B0%D0%B7%D0%B2%D1%91%D1%80%D1%82%D1%8B%D0%B2%D0%B0%D0%BD%D0%B8%D0%B5-%D0%BF%D1%80%D0%BE%D0%B5%D0%BA%D1%82%D0%B0-%D1%81-%D0%BD%D1%83%D0%BB%D1%8F-%D0%BF%D0%BE%D0%B4-Ubuntu-Server).
 
 
-##Участие
+## Участие
 
 * Fork
 * Create a topic branch - `git checkout -b feature-cool-stuff`
@@ -45,7 +45,7 @@
 [guidelines on writing a good commit message](http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html)
 * That's it!
  
-##Лицензия 
+## Лицензия 
 
 The MIT License (MIT)
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
